### PR TITLE
Change or switch to getenv's default

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -12,7 +12,7 @@ __all__: tuple[str, ...] = (
 
 
 class EnvVars:
-    BOT_TOKEN: str = os.getenv("BOT_TOKEN") or ""
+    BOT_TOKEN: str = os.getenv("BOT_TOKEN", "")
 
 
 class Config:


### PR DESCRIPTION
Should be far simpler than checking truthy value ourselves, no?